### PR TITLE
update() to work with promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,11 +218,7 @@ module.exports = function(nforce, pluginName) {
     opts.method = 'PATCH';
     opts.body = JSON.stringify(args.object);
 
-    this._apiRequest(opts, function(err, results) {
-      if (err) { return callback(err, null); }
-      if (!err) { return callback(null, {success: true}); }
-    });
-
+    return this._apiRequest(opts, opts.callback);
   });
 
   // deletes a record by id


### PR DESCRIPTION
This PR allows `update` to work both with callbacks and and with promises. Previously doing `org.tooling.update(...).then(() => dostuff...` would give `callback is not a function`.

I just used the way you're returning out of most of the other functions.

Some of the other methods do this as well, if this update makes sense and doesn't break something I'm not aware of then I will work on another PR for the others. 
