### PR TITLE
Update runTestsAsyncPost to accept methods option

### DIFF
--- a/index.js
+++ b/index.js
@@ -363,7 +363,23 @@ module.exports = function(nforce, pluginName) {
     opts.uri = opts.oauth.instance_url + '/services/data/' + this.apiVersion
         + '/tooling/runTestsAsynchronous/',
     opts.method = 'POST';
-    opts.body = '{"classids":"' + args.ids + '"}';
+    if(!args.methods){
+      opts.body = '{"classids":"' + args.ids + '"}';  
+    }
+    else{
+      validator = false;
+
+      var invalid = _.find(args.methods, function(item){
+        var valid = validate(item, ['classId']);
+        if(valid.error) validator = valid;
+        return valid;
+      });
+
+      if(validator.error) return callback(new Error(validator.message));
+
+      opts.body = JSON.stringify({tests: args.methods})
+    }
+    
 
     this._apiRequest(opts, function(err, results) {
       if (err) { return callback(err, null); }

--- a/test/runTests.js
+++ b/test/runTests.js
@@ -42,6 +42,41 @@ describe('runTests', function() {
             function () {
               org.toolingTests.getAsyncTestResults({ids: [resp.records[0].Id]}, function(err, resp) {
                 if (err) console.log(err);
+                resp.size.should.eql(2);
+                resp.totalSize.should.eql(2);
+                resp.records.should.be.instanceof(Array);
+                resp.records[0].Outcome.should.eql("Pass");
+                done();
+              });
+            }
+          , 5000);
+        });
+      });
+    })
+  });
+
+  describe('#runTestsAsyncSpecificPost', function(done){
+    it('should return test results correctly for the specified tests', function(done){
+      // kick off the job
+      org.toolingTests.runTestsAsyncPost({ids: apexTestClassId, methods: [{classId: apexTestClassId, testMethods:['assertNotName']}]}, function(err, jobId) {
+        if (err) console.log(err);
+        jobId.should.not.be.null;
+        // get the test status
+        org.toolingTests.getAsyncTestStatus({id: jobId}, function(err, resp) {
+          if (err) console.log(err);
+          resp.size.should.eql(1);
+          resp.totalSize.should.eql(1);
+          resp.records.should.be.instanceof(Array);
+          resp.records[0].Id.should.not.be.null;
+          resp.records[0].Status.should.not.be.null;
+          resp.records[0].ApexClassId.should.not.be.null;
+
+          // wait 5 seconds and then get the test results
+          console.log("     Info: Waiting 5 seconds for salesforce tests to finish.");
+          setTimeout(
+            function () {
+              org.toolingTests.getAsyncTestResults({ids: [resp.records[0].Id]}, function(err, resp) {
+                if (err) console.log(err);
                 resp.size.should.eql(1);
                 resp.totalSize.should.eql(1);
                 resp.records.should.be.instanceof(Array);
@@ -53,7 +88,42 @@ describe('runTests', function() {
         });
       });
     })
-  });  
+  })
+
+  describe('#runTestsAsyncPost', function(done){
+    it('should return test results correctly for the test ids using POST', function(done){
+      // kick off the job
+      org.toolingTests.runTestsAsyncPost({ids: apexTestClassId}, function(err, jobId) {
+        if (err) console.log(err);
+        jobId.should.not.be.null;
+        // get the test status
+        org.toolingTests.getAsyncTestStatus({id: jobId}, function(err, resp) {
+          if (err) console.log(err);
+          resp.size.should.eql(1);
+          resp.totalSize.should.eql(1);
+          resp.records.should.be.instanceof(Array);
+          resp.records[0].Id.should.not.be.null;
+          resp.records[0].Status.should.not.be.null;
+          resp.records[0].ApexClassId.should.not.be.null;
+
+          // wait 5 seconds and then get the test results
+          console.log("     Info: Waiting 5 seconds for salesforce tests to finish.");
+          setTimeout(
+            function () {
+              org.toolingTests.getAsyncTestResults({ids: [resp.records[0].Id]}, function(err, resp) {
+                if (err) console.log(err);
+                resp.size.should.eql(2);
+                resp.totalSize.should.eql(2);
+                resp.records.should.be.instanceof(Array);
+                resp.records[0].Outcome.should.eql("Pass");
+                done();
+              });
+            }
+          , 5000);
+        });
+      });
+    })
+  })
 
   // create the apex class and test class
   before(function(done){
@@ -73,7 +143,7 @@ describe('runTests', function() {
             // now insert the test class AFTER the apex class was inserted.
             var apexTestClass = { 
               name: "ToolingApiMocha_Test",
-              body: "@isTest\n private class ToolingApiMocha_Test {\n\n static testMethod void assertName() {\n ToolingApiMocha t = new ToolingApiMocha();\n System.assert(t.getName() == 'name');\n}\n\n}"
+              body: "@isTest\n private class ToolingApiMocha_Test {\n\nstatic testMethod void assertName() {\nToolingApiMocha t = new ToolingApiMocha();\nSystem.assert(t.getName() == 'name');\n}\nstatic testMethod void assertNotName(){\nToolingApiMocha t = new ToolingApiMocha();\nSystem.assert(t.getName() != 'notname');\n}\n\n}"
             };
 
             org.toolingTests.insert({type: 'ApexClass', object: apexTestClass}, function(err, resp) {


### PR DESCRIPTION
Updated the runTestsAsyncPost method to accept a methods option. If
passed, it will utilize the runTestsAsynchronous API method, send it the
JSON payload in the documentation. When passed, it will run only the
tests specified in the testMethods array (if present). You can then run
a whole test class or specific methods in a class.

Salesforce documentation:
https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/intro_rest_resources.htm
